### PR TITLE
feat: Enforce mobile-only interface layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -31,7 +31,7 @@ nav a:hover {
 
 .container {
     padding: 25px;
-    max-width: 1600px; /* Max width for very large screens */
+    max-width: 480px; /* Max width for mobile-like layout */
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
I've modified static/css/style.css to constrain the maximum width of the main content container to 480px. This ensures that the application displays with a mobile-like single-column layout, even when viewed on desktop screens.

The .container class now has max-width: 480px. The existing margin-left: auto and margin-right: auto rules ensure this constrained view is centered on larger viewports.